### PR TITLE
core: adding convert module

### DIFF
--- a/config/convert/default.json
+++ b/config/convert/default.json
@@ -1,5 +1,5 @@
 {
-    "dpi": 300,
+    "dpi": "original",
     "height": "original",
     "width": "original",
     "pages": "all"

--- a/modules/DocumentConverter/ConvertConfigurator.js
+++ b/modules/DocumentConverter/ConvertConfigurator.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const _ = require('lodash');
+
+
+/**
+ * A custom error allows additional warnings and hints.
+ */
+class ConfiguratorError extends Error {
+  constructor(message, ...stack) {
+    super(message);
+    this.name = this.constructor.name;    
+    this.stack = stack.map(line => '?> ' + line).join('\n') + `\n${this.stack}`;
+  }
+}
+
+
+/**
+ * A read-only config object, to prevent outside interference or change 
+ * after initialization.
+ */
+class ConvertConfigurator {
+  static default = {
+    dpi: 'original',
+    height: 'original',
+    width: 'original',
+    pages: 'all'
+  };
+
+  static fromJSON(json) {
+    if (['string', 'object'].every(type => typeof json !== type)) {
+      throw new TypeError(`The given argument must be a JSON string or plain object.`);
+    }
+    const configurator = new ConvertConfigurator;
+    json = typeof json == 'string' ? JSON.parse(json) : json;
+    json = _.chain(this.default).toPlainObject().assign(json).value();
+    _.entries(json).forEach(pairs => configurator.set(...pairs));
+    return configurator;
+  }
+
+  static fromFile(file) {
+    try {
+      const json = fs.readFileSync(file).toString();
+      const configurator = this.fromJSON(json);
+      return configurator;
+    }
+    catch (e) {
+      if (e.code == 'ENOENT' && e.errno == -2) {
+        throw new ConfiguratorError('The given configurator file not found.');
+      }
+      else throw e;
+    }
+  }
+
+  static getDefault() {
+    return ConvertConfigurator.fromJSON(this.default);
+  }
+
+  set(key, value) {
+    if (typeof key !== 'string')
+      throw new TypeError('Configurator key must be a string.');
+
+    try {
+      Object.defineProperty(this, key, {
+        enumerable: true,
+        writable: false,
+        value,
+      });
+    }
+    catch (e) {
+      throw new ConfiguratorError(
+        'Do not interfere and modify the config from the outside after initialization.', 
+        'You can only add.');
+    }
+  }
+}
+
+
+module.exports = ConvertConfigurator;

--- a/modules/DocumentConverter/ConvertEngine.js
+++ b/modules/DocumentConverter/ConvertEngine.js
@@ -78,7 +78,7 @@ class ConvertEngine {
      * pools (each pool runs many smaller processes asynchronously). 
      * The next pool will start after the previous pool ends. Workers 
      * run asyncronously, too. Admin can adjust the pool limit from outside.
-     * @type {ProcessWorker}
+     * @type {ProcessWorker[]}
      * @protected
      */
     this._workers = [];
@@ -90,7 +90,7 @@ class ConvertEngine {
    */
   setDefaultConfigurator(config) {
     if (config instanceof ConvertConfigurator) {
-      this._config = config;
+      this._defaultConfig = config;
     }
     return this;
   }
@@ -112,7 +112,7 @@ class ConvertEngine {
    * corresponding Worker. 
    * @param {string} source - Source file
    * @param {string} dest - Destination folder
-   * @param {ConvertConfigurator} options 
+   * @param {Object} options 
    */
   addFile(source, dest, options = {}) {
     if (this._workers.length >= this._maxConcurrency) {

--- a/modules/DocumentConverter/ConvertEngine.js
+++ b/modules/DocumentConverter/ConvertEngine.js
@@ -1,0 +1,207 @@
+const ProcessWorker = require('./engine/ProcessWorker');
+const ConvertConfigurator = require('./ConvertConfigurator');
+
+const submodules = {
+  split: [
+    require('./builder/splitters/PDFTK_Builder'),
+  ],
+  convert: [
+    require('./builder/converters/PDF2PPM_Builder'),
+    require('./builder/converters/PDF2SVG_Builder'),
+  ],
+};
+
+
+class ConvertError extends Error {
+  constructor(message, ...stack) {
+    super(message);
+    this.name = this.constructor.name;    
+    this.stack = stack.map(line => '?> ' + line).join('\n') + `\n${this.stack}`;
+  }
+}
+
+
+/**
+ * @classdesc Multi-threaded support document converter engine.
+ */
+class ConvertEngine {
+  constructor() {
+    this.running = false;
+    this.stopped = false;
+    
+    /**
+     * Default config. Use for all worker if specified.
+     * @type {ConvertConfigurator|null}
+     * @protected
+     */
+    this._defaultConfig = null;
+
+    /**
+     * Default options apply for each convert session.
+     * @type {Object}
+     * @protected
+     */
+    this._defaultOptions = {
+      split: true,
+      convert: true,
+      inputExtension: 'pdf',
+      outputExtension: 'svg',
+      hooks: {
+        clearCache: true,
+        resolveBadNaming: true
+      }
+    }
+
+    /**
+     * Number of concurrently workers. Default is 1.
+     * @type {Number<Int>}
+     * @protected
+     */
+    this._maxConcurrency = 1;
+
+    /**
+     * Number of parallel threads limit. Default is 20.
+     * @type {Number<Int>}
+     * @protected
+     */
+    this._maxThread = 20;
+
+    /**
+     * Number of threads in safe for the system. Default is 10.
+     * @type {Number<Int>}
+     * @protected
+     */
+    this._maxThreadSafe = 10;
+
+    /**
+     * The array contains many ProcessWorkers. Each worker may have numerous 
+     * pools (each pool runs many smaller processes asynchronously). 
+     * The next pool will start after the previous pool ends. Workers 
+     * run asyncronously, too. Admin can adjust the pool limit from outside.
+     * @type {ProcessWorker}
+     * @protected
+     */
+    this._workers = [];
+  }
+
+  /**
+   * Install an alternative configurator for the engine 
+   * @param {ConvertConfigurator} config
+   */
+  setDefaultConfigurator(config) {
+    if (config instanceof ConvertConfigurator) {
+      this._config = config;
+    }
+    return this;
+  }
+
+  /**
+   * For stability, the number of concurrency should not exceed 5. 
+   * @param {Number<Int>} con
+   */
+  setMaxConcurrency(con) {
+    if (typeof con !== 'number') return this;
+    if (con > 5) 
+      console.warn('For stability, the number of concurrency should not exceed 5.');
+    this._maxConcurrency = con;
+    return this;
+  }
+
+  /**
+   * Add a file into list. Each file added will be handled by a 
+   * corresponding Worker. 
+   * @param {string} source - Source file
+   * @param {string} dest - Destination folder
+   * @param {ConvertConfigurator} options 
+   */
+  addFile(source, dest, options = {}) {
+    if (this._workers.length >= this._maxConcurrency) {
+      console.error('Reach limit of concurrently');
+      return;
+    }
+
+    const _default = { ...this._defaultOptions };
+    const _options = Object.keys(_default).reduce(function overwriteOptions(result, key) {
+      if (typeof _default[key] == 'object') {
+        const _old = _default[key];
+        const _new = options[key] || {};
+        result[key] = { ..._old, ..._new };
+        return result;
+      }
+      else if (options[key] !== undefined) {
+        result[key] = options[key];
+      }
+      return result
+    }, _default);
+
+    const inputExtension = _options.inputExtension || 'pdf';
+    const outputExtension = _options.outputExtension || 'pdf';
+
+    const splitter = submodules.split.find(mod => mod.inputSupported == inputExtension);
+    const converter = submodules.convert.find(mod =>
+      mod.inputSupported == inputExtension &&
+      mod.outputSupported.includes(outputExtension));
+
+    const configurator = options.configurator || this._defaultConfig || ConvertConfigurator.getDefault();
+    const worker = new ProcessWorker(configurator)
+      .setEngine(this)
+      .setConverter(converter)
+      .setInput(source)
+      .setOutput(dest)
+      .setOptions(_options)
+
+    /**
+     * Temporarily disallow phase skipping. The system will be overloaded 
+     * if too many threads access the same file. The current better 
+     * workaround is split the file and cache it.
+     */
+    // if (_options.split)
+    //   worker.setSplitter(splitter);
+    // if (_options.convert)
+    //   worker.setConverter(converter);
+    
+    worker.setSplitter(splitter);
+    worker.setConverter(converter);
+    
+    this._workers.push(worker);
+    return this;
+  }
+
+  convert() {
+    const self = this;
+    this.running = true;
+    this.stopped = false;
+    return new Promise((resolve, reject) => {
+      Promise.all(this._workers.map(worker => worker.convert()))
+        .then(response => {
+          const resultAll = response.map(workerResponse => {
+            const result = {};
+            
+            result.pools = workerResponse.pools;
+            result.hooks = Array.isArray(workerResponse.hooks.custom)
+              ? workerResponse.hooks.custom.map(invoke => invoke())
+              : [];
+
+            if (Array.isArray(workerResponse.hooks.builtin)) {
+              workerResponse.hooks.builtin.forEach(invoke => invoke());
+            }
+
+            self._workers = [];
+            self.running = false;
+            self.stopped = true;
+            return result;
+          });
+
+          resolve(resultAll);
+        })
+        .catch(reason => {
+          self.running = false;
+          self.stopped = true;
+          reject(reason);
+        });
+    })
+  }
+}
+
+
+module.exports = ConvertEngine;

--- a/modules/DocumentConverter/builder/CommandBuilder.js
+++ b/modules/DocumentConverter/builder/CommandBuilder.js
@@ -1,0 +1,149 @@
+const fs = require('fs');
+const path = require('path');
+const child_process = require('child_process');
+const _ = require('lodash')
+
+
+const isTesting = function isTesting(tool) {
+  try {
+    const resolved = require.resolve(tool).toString();
+    const acceptTestTools = ['ava', 'mocha', 'jest', 'tap'];
+    if (acceptTestTools.some(test => RegExp(`/node_modules/${test}/.*\\.js`).test(resolved))) {
+      return true;
+    }
+  }
+  catch(err) {
+    return false;
+  }
+}
+
+
+/**
+ * @class
+ * @classdesc Build flexible command by specified settings.
+ */
+class CommandBuilder {
+  constructor(opts = {}) {
+    // Path of executor
+    this.executor = '';
+
+    // Key, value pairs are equivalent to command options 
+    this.options = {};
+
+    // Options aliases
+    this.aliases = {};
+
+    // Command parts arranged in order, mainly used for command build purposes
+    this.arrange = ['$command', '$input', '$options', '$output'];
+
+    this._ = opts;
+
+    if (this._.testing && isTesting(this._.testing)) {
+      Object.defineProperty(this, '_ignoreError', {
+        configurable: false,
+        value: true
+      })
+    }
+  }
+
+  rearrange(arrange) {
+    const needed = ['$command', '$input', '$options', '$output'];
+
+    if (!Array.isArray(arrange) && !needed.every(part => arrange.includes(part))) {
+      throw new Error('A standard command needs to have all the parts including: command, input, option, output.');
+    }
+
+    this.arrange = arrange;
+    return this;
+  }
+
+  /**
+   * @param {string} input - Path to input file
+   * @param {string} output - Path to output file
+   * @param {Object} options
+   * @return {Array}
+   */
+  build(input, output, options = {}) {
+    const aliasesKeys = Object.keys(this.aliases);
+    const optionsKeys = Object.keys(this.options);
+
+    const self = this;
+    const interpreted = [];
+    const command = [];
+
+    if (options.resolveTilde) {
+      input = this._resolveTilde(input);
+      output = this._resolveTilde(output);
+    }
+
+    const isDirectory = fs.existsSync(output) && fs.statSync(output).isDirectory();
+    const isSpecifiedExtensionOutput = this.options && typeof this.options.outputExtension == 'string';
+
+    this._isValidInputFile(input);
+
+    if (isDirectory || (isSpecifiedExtensionOutput && options.addOutputExtension)) {
+      const inputFileName = typeof options.customFileName == 'string'
+        ? options.customFileName
+        : path.parse(input).name;
+      const outputExtension = this.options.outputExtension
+        ? `.${this.options.outputExtension}` : '';
+      
+      output = options.addOutputExtension 
+        ? path.join(output, `${inputFileName}${outputExtension}`)
+        : path.join(output, inputFileName);
+    }
+
+    aliasesKeys.forEach(key => {
+      const option = this.aliases[key];
+      const value = this.options[key];
+
+      // Only push if the value of that option is already set 
+      if (value) {
+        typeof value == 'boolean' ? interpreted.push(option) : interpreted.push([ option, value ]);
+      }
+    });
+
+    this.arrange.forEach(part => {
+      switch (part) {
+        case '$command':
+          command.push(self.executor);
+          break;
+        case '$input':
+          command.push(input);
+          break;
+        case '$output':
+          command.push(output);
+          break;
+        case '$options':
+        case '$option':
+          command.push(interpreted);
+          break;
+        default:
+          command.push(part);
+      }
+    });
+
+    const commandAsString = _.flattenDeep(command).join(' ').trim();
+    return options.returnString ? commandAsString : command;
+  }
+
+  /**
+   * Check whether the input file is valid
+   * @protected
+   */
+  _isValidInputFile(input) {
+    if (!this._ignoreError && !fs.existsSync(input))
+      throw new Error(`No such file: ${input}`);
+  }
+
+  /**
+   * Replace tilde with its own real path. Only on Linux.
+   * @protected
+   */
+  _resolveTilde(str) {
+    return str.startsWith('~') ? path.join(process.env.HOME, str.slice(1)) : str;
+  }
+}
+
+
+module.exports = CommandBuilder;

--- a/modules/DocumentConverter/builder/converters/PDF2PPM_Builder.js
+++ b/modules/DocumentConverter/builder/converters/PDF2PPM_Builder.js
@@ -1,0 +1,106 @@
+const PDFConverterBuilder = require('./PDFConverterBuilder');
+
+
+/**
+ * Convert PDF to images (vector to bitmap)
+ * @class 
+ * @inheritdoc
+ */
+class PDF2PPM_Builder extends PDFConverterBuilder {
+  static outputSupported = ['png', 'jpeg', 'tiff'];
+
+  constructor(opts = {}) {
+    super(opts);
+    this.executor = 'pdftoppm';
+    
+    this.options = {
+      ...this.options,
+      dpi: null,
+      scaleToX: null,
+      scaleToY: null,
+      fromPage: null,
+      toPage: null,
+    }
+
+    this.aliases = {
+      dpi: '-r',
+      scaleToX: '-scale-to-x',
+      scaleToY: '-scale-to-y',
+      fromPage: '-f',
+      toPage: '-l'
+    }
+
+    this.outputSupported = this.constructor.outputSupported;
+    this.arrange = ['$command', '$_extension', '$options', '$input', '$output'];
+  }
+
+  /**
+   * Specifies the X and Y resolution, in DPI.
+   * @param {Number<Int>} dpi
+   */
+  setDPI(dpi) {
+    this.options.dpi = dpi;
+    return this;
+  }
+
+  /**
+   * Scales each page horizontally to fit in scale-to-x pixels.
+   * @param {Number<Float>} scale
+   */
+  setWidth(scale) {
+    this.options.scaleToX = scale;
+    return this;
+  }
+
+  /**
+   * Scales each page vertically to fit in scale-to-y pixels.
+   * @param {Number<Float>} scale
+   */
+  setHeight(scale) {
+    this.options.scaleToY = scale;
+    return this;
+  }
+
+  /**
+   * Convert from page
+   * @param {Number<Int>} page
+   */
+  convertFromPage(page) {
+    this.options.fromPage = page;
+    return this;
+  }
+
+  /**
+   * Convert to page
+   * @param {Number<Int>} page
+   */
+  convertToPage(page) {
+    this.options.toPage = page;
+    return this;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  build(input, output, options = {}) {
+    const outputExtension = this.options.outputExtension;
+    const backup = [...this.arrange];
+    if (!this._ignoreError && !this.options.outputExtension) {
+      throw new Error('Output extension has not been specify');
+    }
+    if (!this._ignoreError && !this.outputSupported.includes(outputExtension)) {
+      throw new Error('This extension is not supported');
+    }
+
+    const extReplacement = `-${outputExtension}`;
+    const replaceIndex = this.arrange.findIndex(part => part == '$_extension');
+    this.arrange[replaceIndex] = extReplacement;
+    
+    const completeCommand = super.build(input, output, options);
+    this.arrange = backup;
+    return completeCommand;
+  }
+}
+
+
+module.exports = PDF2PPM_Builder;

--- a/modules/DocumentConverter/builder/converters/PDF2SVG_Builder.js
+++ b/modules/DocumentConverter/builder/converters/PDF2SVG_Builder.js
@@ -1,0 +1,63 @@
+const PDFConverterBuilder = require('./PDFConverterBuilder');
+
+
+/**
+ * Convert PDF to SVG (vector to vector)
+ * @class
+ * @inheritdoc
+ */
+class PDF2SVG_Builder extends PDFConverterBuilder {
+  static outputSupported = ['svg'];
+
+  constructor(opts = {}) {
+    super(opts);
+    this.executor = 'pdf2svg';
+    this.outputSupported = this.constructor.outputSupported;
+    this.options = {
+      ...this.options,
+      outputExtension: 'svg',
+      page: null
+    }
+    this.arrange = ['$command', '$options', '$input', '$output', '$_page'];
+  }
+
+  /**
+   * @inheritdoc
+   */
+  setOutputExtension(ext) {
+    return this;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  setSpecifiedPage(page) {
+    this.options.page = page;
+    return this;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  build(input, output, options = {}) {
+    const outputExtension = this.options.outputExtension;
+
+    if (!this._ignoreError && !this.outputSupported.includes(outputExtension)) {
+      throw new Error('This extension is not supported');
+    }
+
+    if (Number.isInteger(this.options.page)) {
+      const specifiedPage = this.arrange.findIndex(part => part == '$_page');
+      this.arrange[specifiedPage] = this.options.page.toString();
+    }
+    else {
+      this.arrange = this.arrange.filter(part => part != '$_page');
+    }
+
+    const completedCommand = super.build(input, output, { addOutputExtension: true, ...options });
+    return completedCommand;
+  }
+}
+
+
+module.exports = PDF2SVG_Builder;

--- a/modules/DocumentConverter/builder/converters/PDFConverterBuilder.js
+++ b/modules/DocumentConverter/builder/converters/PDFConverterBuilder.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const _ = require('lodash');
+const CommandBuilder = require('../CommandBuilder');
+
+
+/**
+ * Build a complete command for a file converter
+ * @class
+ * @inheritdoc
+ */
+class PDFConverterBuilder extends CommandBuilder {
+  static inputSupported = 'pdf';
+  static outputSupported = ['pdf'];
+
+  constructor(opts = {}) {
+    super(opts);
+
+    this.inputSupported = this.constructor.inputSupported;
+    this.outputSupported = this.constructor.outputSupported;
+
+    this.options = {
+      inputExtension: 'pdf',
+      outputExtension: null,
+    }
+  }
+
+  /**
+   * Set file extension input
+   * @param {string} ext
+   */
+  setInputExtension(ext) {
+    this.options.inputExtension = ext;
+    return this;
+  }
+
+  /**
+   * Set file extension output
+   * @param {string} ext
+   */
+  setOutputExtension(ext) {
+    this.options.outputExtension = ext;
+    return this;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  build(input, output, options = {}) {
+    const backup = [...this.arrange];
+    const excludedExtensionOptions = _.omit(this.options, [ 'inputExtension', 'outputExtension' ]);
+    
+    if (this.options.inputExtension == this.options.outputExtension 
+      && Object.values(excludedExtensionOptions).every(value => !value)) {
+      this.arrange = ['cp', '$input', '$output'];
+    }
+    const completeCommand = super.build(input, output, options);
+    this.arrange = backup;
+    return completeCommand;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  _isValidInputFile(input) {
+    super._isValidInputFile(input);
+    if (!this._ignoreError && !fs.statSync(input).isFile()) throw new Error('The given input path must be a file');
+  }
+}
+
+
+module.exports = PDFConverterBuilder;

--- a/modules/DocumentConverter/builder/splitters/PDFSplitterBuilder.js
+++ b/modules/DocumentConverter/builder/splitters/PDFSplitterBuilder.js
@@ -1,0 +1,42 @@
+const CommandBuilder = require('../CommandBuilder');
+
+
+/**
+ * Build a complete command for a file splitter
+ * @class
+ * @inheritdoc
+ */
+class PDFSplitterBuilder extends CommandBuilder {
+  static inputSupported = 'pdf';
+  static outputSupported = ['pdf'];
+
+  constructor(opts = {}) {
+    super(opts);
+
+    this.inputSupported = this.constructor.inputSupported;
+    this.outputSupported = this.constructor.outputSupported;
+
+    Object.defineProperties(this.options, {
+      inputExtension: {
+        enumerable: true,
+        writable: false, 
+        value: 'pdf'
+      },
+      outputExtension: {
+        enumerable: true,
+        writable: false,
+        value: 'pdf'
+      }
+    });
+  }
+
+  /**
+   * @inheritdoc
+   */
+  build(input, output, options = {}) {
+    return super.build(input, output, options);
+  }
+}
+
+
+module.exports = PDFSplitterBuilder;

--- a/modules/DocumentConverter/builder/splitters/PDFTK_Builder.js
+++ b/modules/DocumentConverter/builder/splitters/PDFTK_Builder.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+const PDFSplitterBuilder = require('./PDFSplitterBuilder');
+
+
+/**
+ * Split PDF file to separate file, page by page
+ * @class
+ * @inheritdoc
+ */
+class PDFTK_Builder extends PDFSplitterBuilder {
+  constructor(opts = {}) {
+    super(opts);
+    this.executor = 'pdftk';
+    this.arrange = ['$command', '$input', 'burst', 'output', '$output'];
+  }
+
+  /**
+   * @inheritdoc
+   */
+  build(input, output, options = {}) {
+    const parsed = path.parse(output);
+
+    // PDFTK will throw a java.io.FileNotFoundException if you do not 
+    // specify output filepattern.
+    // Therefore, I will make the default one for you.
+    if (!parsed.name.includes('%d')) {
+      const _output = this._resolveTilde(output);
+      const outputIsDirectory = fs.existsSync(_output) && fs.statSync(_output).isDirectory();
+
+      if (outputIsDirectory) {
+        output = path.join(output, `%d.${this.options.outputExtension}`);
+      }
+      else {
+        output = path.join(parsed.dir, `${parsed.name}_%d.${parsed.ext || this.options.outputExtension}`);
+      }
+    }
+
+    return super.build(input, output, options);
+  }
+}
+
+
+module.exports = PDFTK_Builder;

--- a/modules/DocumentConverter/engine/LinkableCommand.js
+++ b/modules/DocumentConverter/engine/LinkableCommand.js
@@ -1,0 +1,277 @@
+const child_process = require('child_process');
+const _private = new WeakMap();
+
+
+/**
+ * A chainable command executor (Doubly Linked List)
+ */
+class LinkableCommand {
+  /**
+   * @param {string} command
+   * @param {Object} options
+   */
+  constructor(command, options = {}) {
+    /**
+     * Init a private context
+     */
+    const property = {}
+    _private.set(this, property);
+
+    /**
+     * @type {string}
+     */
+    this.command = command || '';
+
+    /**
+     * @type {boolean}
+     */
+    this.verbose = options.verbose || false;
+
+    /**
+     * Number of command in sequence
+     * @type {Number<Int>}
+     */
+    this.length = 1;
+
+    /**
+     * Index of command in sequence
+     * @type {Number<Int>}
+     */
+    this.index = 0;
+
+    /**
+     * The next command will be run automatically after the current command 
+     * finished.
+     * @type {?LinkableCommand}
+     * @private
+     */
+    _private.get(this).next = null;
+
+    /**
+     * Point to the previous command. Mainly used for backtracking linked list.
+     * @type {?LinkableCommand}
+     * @private
+     */
+    _private.get(this).prev = null;
+
+    /**
+     * Update all elements of the linked list when a new command is appended.
+     * @private
+     */
+    _private.get(this).update = (function update() {
+      let length = this.getLast().index + 1;
+
+      this.fromFirst(current => {
+        current.length = length;
+      })
+    }).bind(this);
+  }
+
+  /**
+   * Get next command
+   * @return {?LinkableCommand}
+   */
+  getNext() {
+    return _private.get(this).next;
+  }
+
+  /**
+   * Get prev command
+   * @return {?LinkableCommand}
+   */
+  getPrev() {
+    return _private.get(this).prev;
+  }
+
+  /**
+   * Append a command to the sequence
+   * @param {string|LinkableCommand}
+   * @return {?LinkableCommand} - The next command
+   */
+  setNext(command) {
+    if (command instanceof LinkableCommand) {
+      const executor = command;
+      _private.get(this).next = executor;
+      _private.get(executor).prev = this;
+      this.length++
+
+      executor.index = this.index + 1;
+      _private.get(this).update();
+      return executor;
+    }
+    else if (typeof command == 'string') {
+      const executor = new LinkableCommand(command)
+      _private.get(this).next = executor;
+      _private.get(executor).prev = this;
+      this.length++;
+
+      executor.index = this.index + 1;
+      _private.get(this).update();
+      return executor;
+    }
+  }
+
+  /**
+   * Get the first command, regardless of anywhere in the sequence
+   * @return {!LinkableCommand}
+   */
+  getFirst() {
+    let current = this;
+    let prev = current.getPrev();
+
+    while (prev) {
+      current = prev;
+      prev = prev.getPrev();
+    }
+    return current;
+  }
+
+  /**
+   * Get the last command, regardless of anywhere in the sequence
+   * @return {!LinkableCommand}
+   */
+  getLast() {
+    let current = this;
+    let next = current.getNext();
+
+    while (next) {
+      current = next;
+      next = next.getNext()
+    }
+    return current;
+  }
+
+  /**
+   * Loop through all commands of the linked list, starting from the 
+   * first one.
+   * @param {Function} callback
+   */
+  fromFirst(callback) {
+    let current = this.getFirst();
+    let next = current.getNext();
+    while (next) {
+      callback(current);
+      current = next;
+      next = next.getNext();
+    }
+    callback(current);
+  }
+
+  /**
+   * Enable verbose for all commands in chain.
+   * Verbose of the next command will obey the negative of the first 
+   * command. 
+   */
+  toggleVerbose() {
+    const verbose = !this.getFirst().verbose;
+    this.fromFirst(current => {
+      current.verbose = verbose;
+    })
+    return this;
+  }
+
+  /**
+   * Get the n-th command in sequence.
+   * @return {?LinkableCommand}
+   */
+  commandAt(n) {
+    if (n > this.length - 1) return;
+
+    let current = this.getFirst();
+    let index = current.index;
+
+    while (index < n) {
+      current = current.getNext();
+      index = current.index
+    }
+    return current;
+  }
+
+  /**
+   * Check whether a command belongs to the current linked list
+   * @param {LinkableCommand}
+   * @return {boolean}
+   */
+  inSequence(command) {
+    let isExecutor = command instanceof LinkableCommand;
+    let isInSequence = false;
+
+    if (!isExecutor) return false;
+
+    this.fromFirst(current => {
+      if (current == command) {
+        isInSequence = true;
+      }
+    });
+    return isInSequence;
+  }
+
+  /**
+   * Get an array of all the commands in the linked list. 
+   * Note: They will continue to keep reference to each other. 
+   * @param {Function} callback - Map function
+   * @return {Array}
+   */
+  toArray(callback) {
+    const array = [];
+    this.fromFirst(current => {
+      if (typeof callback == 'function')
+        array.push(callback(current));
+      else
+        array.push(current);
+    })
+    return array;
+  }
+
+  /**
+   * Run the command from this one onwards, not included the preceding commands 
+   */
+  run(options = {}) {
+    const self = this;
+    const stdout = options.stdout || process.stdout;
+    const ignoreError = options.ignoreError || false;
+
+    if (self.command) {
+      return new Promise(function (resolve, reject) {
+        const proc = child_process.spawn(self.command, { shell: true })
+          .on('spawn', () => {
+            if (self.verbose) {
+              console.log(`Spawning process: '${self.command}'`);    
+              proc.stdout.pipe(stdout);
+            }
+            if (typeof options.onSpawn == 'function') {
+              options.onSpawn(self, proc.stdout);
+            }
+          })
+          .on('error', error => {
+            if (typeof options.onError == 'function') {
+              options.onError(self, error, proc.stderr);
+            }
+            else if (!ignoreError) reject(error);
+          })
+          .on('exit', (code, signal) => {
+            if (typeof options.onExit == 'function') {
+              options.onExit(self, proc.stdout);
+            }
+            if (self.verbose) {
+              console.log(`Closing process: '${self.command}'`)
+            }
+            if (self.getNext() instanceof LinkableCommand) {
+              resolve(self.getNext().run(options));
+            }
+            else {
+              resolve({
+                process: proc,
+                command: self.getFirst()
+              });
+            }
+          });
+      });
+    }
+    else
+      return Promise.resolve();
+  }
+}
+
+
+module.exports = LinkableCommand;

--- a/modules/DocumentConverter/engine/ProcessWorker.js
+++ b/modules/DocumentConverter/engine/ProcessWorker.js
@@ -1,0 +1,412 @@
+const fs = require('fs');
+const path = require('path');
+const _ = require('lodash');
+const LinkableCommand = require('./LinkableCommand');
+const PDFSplitter = require('./adapters/splitters/PDFSplitAdapter');
+const PDFConverter = require('./adapters/converters/PDFConvertAdapter');
+const ThreadPool = require('./ThreadPool');
+const PDFInfo = require('../util/info');
+const _private = new WeakMap();
+
+
+class ProcessWorker {
+  constructor(config) {
+    /**
+     * Init a private context
+     */
+    const property = {}
+    const self = this;
+    _private.set(this, property);
+
+    /**
+     * Cache folder
+     * @private
+     */
+    _private.get(this)._cache = path.resolve(__dirname, '..', '.cache');
+
+    /**
+     * Task queue
+     * @type {ThreadPool[]}
+     * @private
+     */
+    _private.get(this).tasks = [];
+
+    /**
+     * Convert configurator
+     * @type {ConvertConfigurator}
+     * @private
+     */
+    _private.get(this).configurator = config;
+
+    /**
+     * Create random pid
+     * @private
+     */
+    _private.get(this).createRandomPID = () => Date.now().toString() + Math.random().toString(10).slice(2, 4);
+
+    /**
+     * Define readonly property
+     * @private
+     */
+    _private.get(this).setReadOnly = (owner, property) => {
+      Object.defineProperty(self, property, {
+        enumerable: true,
+        get: () => owner[property]
+      })
+    }
+
+    this.source = null;
+    this.dest = null;
+    this.done = false;
+
+    _private.get(this).setReadOnly(_private.get(this), '_cache');
+    _private.get(this).setReadOnly(_private.get(this), 'configurator');
+    _private.get(this).setReadOnly(_private.get(this), 'converter');
+    _private.get(this).setReadOnly(_private.get(this), 'splitter');
+    _private.get(this).setReadOnly(_private.get(this), 'options');
+
+    Object.defineProperty(this, 'taskCount', {
+      enumerable: true,
+      get: function getTaskCount() {
+        return _private.get(self).tasks.length;
+      }
+    })
+
+    this._id = _private.get(this).createRandomPID();
+    while (fs.existsSync(path.resolve(_private.get(this)._cache, this._id))) {
+      this._id = _private.get(this).createRandomPID();
+    }
+
+    if (!fs.existsSync(_private.get(this)._cache)) {
+      fs.mkdirSync(_private.get(this)._cache);
+    }
+  }
+
+  /**
+   * @param {ConvertEngine} engine
+   */
+  setEngine(engine) {
+    const context = _private.get(this);
+    context.engine = engine;
+    return this;
+  }
+
+  /**
+   * @param {SplitterBuilder} splitter
+   */
+  setSplitter(splitter) {
+    const context = _private.get(this);
+    context.splitter = splitter;
+    return this;
+  }
+
+  /**
+   * @param {ConverterBuilder} builder
+   */
+  setConverter(converter) {
+    const context = _private.get(this);
+    context.converter = converter;
+    return this;
+  }
+
+  /**
+   * The temporary directory contains intermediate conversion files.
+   * @param {string} dir
+   */
+  setTempFolder(dir) {
+    const context = _private.get(this);
+    context._cache = dir;
+    return this;
+  }
+
+  /**
+   * @param {Object} options
+   */
+  setOptions(options) {
+    const context = _private.get(this);
+    context.options = options;
+    return this;
+  }
+
+  /**
+   * @param {string} input
+   * @param {string} output
+   */
+  setExtensions(input, output) {
+    if (input) this.inputExtension = input;
+    if (output) this.outputExtension = output;
+    return this;
+  }
+
+  /**
+   * @param {string} source
+   */
+  setInput(source) {
+    this.source = source;
+    return this;
+  }
+
+  /**
+   * @param {string} dest
+   */
+  setOutput(dest) {
+    this.dest = dest;
+    return this;
+  }
+
+  /**
+   * @return {Promise) 
+   */
+  async convert() {
+    // Deadline coming
+    const self = this;
+    const _cache = this._cache;
+    const tasks = _private.get(this).tasks;
+    const engine = _private.get(this).engine;
+    const configurator = _private.get(this).configurator
+    const temporaryFolder = path.resolve(_cache, this._id);
+    const inputExtension = this.options.inputExtension;
+    const outputExtension = this.options.outputExtension;
+
+    if (!fs.existsSync(temporaryFolder)) fs.mkdirSync(temporaryFolder); 
+
+    const splitPool = new ThreadPool();
+    const convertPool = new ThreadPool();
+
+    if (_private.get(this).splitter) tasks.push(splitPool);
+    if (_private.get(this).converter) tasks.push(convertPool);
+
+    if (_private.get(this).splitter) {
+      const targetFolder = tasks.length > 1 ? path.resolve(temporaryFolder, 'pdf') : this.dest;
+      if (!fs.existsSync(targetFolder)) fs.mkdirSync(targetFolder);
+
+      const splitter = new PDFSplitter(configurator)
+        .setBuilder(this.splitter)
+        .setInput(this.source)
+        .setOutput(targetFolder)
+        .setOptions({ inputExtension, outputExtension: inputExtension }) // PDF -> PDF
+        .getExecutable();
+
+      splitPool
+        .setPoolSize(1)
+        .addInvoker(function invokeSplitter() {
+          return splitter.run({
+            ignoreError: true,
+            onSpawn: function beforeProcessStart(self, stdout) {
+              console.log(`Starting process "PDFSplitter"`);
+              console.log(`Extracting PDF into "${targetFolder}"`);
+              stdout.pipe(process.stdout);
+            },
+            onExit: function  beforeProcessDone(self, stdout) {
+              console.log(`Closing process "PDFSplitter"`);
+            }
+          });
+        });
+    }
+
+    if (_private.get(this).converter) {
+      const targetFolder = this.dest;
+      const splitBeforeConvert = splitPool.size > 0 && _private.get(this).splitter;
+      if (!fs.existsSync(targetFolder)) fs.mkdirSync(targetFolder);
+
+      if (splitBeforeConvert) {
+        splitPool.setAfter(async function () {
+          const prevFolder = path.resolve(temporaryFolder, 'pdf');
+          const splittedFiles = fs.readdirSync(prevFolder)
+            .map(file => path.resolve(prevFolder, file))
+            .filter(file => file.endsWith(`.${inputExtension}`));
+          const commands = [];
+          const converter = new PDFConverter(configurator)
+              .setBuilder(self.converter)
+              .setOptions({ inputExtension, outputExtension });
+
+          for await (const file of splittedFiles) {
+            converter
+              .setInput(file)
+              .setOutput(targetFolder)
+              
+            const _converter = await converter.getExecutable()
+
+            commands.push(_converter);
+          }
+          
+          const number_of_workers = engine._workers.length;
+          const thread_limiter = number_of_workers < 2 
+            ? engine._maxThreadSafe 
+            : Math.floor(engine._maxThreadSafe / number_of_workers);
+          const chunks = _.chunk(commands, thread_limiter);
+          
+          const heads = chunks.shift().map((head, index) => {
+            let current = head;
+          
+            for (const chunk of chunks) {
+              const command = chunk[index];
+              
+              if (command instanceof LinkableCommand) {
+                current.setNext(command);
+                current = command;
+              }
+            }
+
+            return head;
+          });
+
+          convertPool.setPoolSize(thread_limiter)
+
+          let count = 0;
+          // let threads_count = 0;
+          const start = new Date;
+          for (const head of heads) {
+            convertPool.addInvoker(function invokeConverter() {
+              return head.run({
+                ignoreError: true,
+                onSpawn: function beforeProcessStart(self, stdout) {
+                  // threads_count++; console.log(threads_count);
+                  count++;
+                  console.log(`Spawning process ${count}: "${self.command}"`);
+                  stdout.pipe(process.stdout);
+                },
+                onExit: function  beforeProcessDone(self, stdout) {
+                  // threads_count--; console.log(threads_count);
+                  const now = new Date;
+                  const cost = (now - start) / 1000;
+                  console.log(`Closing process ${count}: "${self.command}" -> ${cost.toFixed(2).toString()}s`)
+                  if (count == commands.length) {
+                    const end = new Date;
+                    const costend = (end - start) / 1000;
+                    console.log(`Total convert time: ${costend.toFixed(2).toString()}s`);
+                  }
+                }
+              })
+            })
+          }
+
+          splitPool.setNext(convertPool);
+        });
+      }
+      else {
+        // TODO: Fix bug convert without split
+        const source = this.source;
+        const dest = this.dest;
+        const commands = [];
+
+        const info = await PDFInfo.getDocumentInfo(source);
+        const pages = Array.isArray(info.pageIndices) ? info.pageIndices : [];
+        const converter = new PDFConverter(configurator)
+          .setBuilder(self.converter)
+          .setInfo(info)
+          .setOptions({ inputExtension, outputExtension })
+
+        for await (const page of pages) {
+          converter
+            .setInput(source)
+            .setOutput(dest)
+            .fromPage(page)
+            .toPage(page)
+
+          const _converter = await converter.getExecutable({ customFileName: page.toString() });
+
+          commands.push(_converter);
+        }
+
+        const number_of_workers = engine._workers.length;
+        const thread_limiter = number_of_workers < 2 
+          ? engine._maxThreadSafe 
+          : Math.floor(engine._maxThreadSafe / number_of_workers);
+        const chunks = _.chunk(commands, thread_limiter);
+        
+        const heads = chunks.shift().map((head, index) => {
+          let current = head;
+        
+          for (const chunk of chunks) {
+            const command = chunk[index];
+            
+            if (command instanceof LinkableCommand) {
+              current.setNext(command);
+              current = command;
+            }
+          }
+
+          return head;
+        });
+
+        convertPool.setPoolSize(thread_limiter)
+
+        let count = 0;
+        // let threads_count = 0;
+        const start = new Date;
+        for (const head of heads) {
+          convertPool.addInvoker(function invokeConverter() {
+            return head.run({
+              ignoreError: true,
+              onSpawn: function beforeProcessStart(self, stdout) {
+                // threads_count++; console.log(threads_count);
+                count++;
+                console.log(`Spawning process ${count}: "${self.command}"`);
+                stdout.pipe(process.stdout);
+              },
+              onExit: function  beforeProcessDone(self, stdout) {
+                // threads_count--; console.log(threads_count);
+                const now = new Date;
+                const cost = (now - start) / 1000;
+                console.log(`Closing process ${count}: "${self.command}" -> ${cost.toFixed(2).toString()}s`)
+                if (count == commands.length) {
+                  const end = new Date;
+                  const costend = (end - start) / 1000;
+                  console.log(`Total convert time: ${costend.toFixed(2).toString()}s`);
+                }
+              }
+            })
+          })
+        }
+      }
+    }
+
+    return Promise.resolve(tasks[0].run())
+      .then(fulfilled => {
+        const responseData = {
+          pools: fulfilled,
+          hooks: {
+            custom: [],
+            builtin: [],
+          },
+        }
+
+        const hooks = require('./hooks/AfterSession');
+        const options = {
+          cache: path.resolve(_private.get(self)._cache, this._id),
+          input: self.source,
+          output: self.dest,
+        };
+
+        Object.keys(self.options.hooks).forEach(name => {
+          const hook = self.options.hooks[name];
+          if (typeof hook == 'function') {
+            const callHook = hook;
+            const invoker = function invokeCustomHook() {
+              return callHook(options)
+            };
+            responseData.hooks.custom.push(invoker)
+          }
+        })
+
+        Object.keys(hooks).forEach(fname => {
+          const func = hooks[fname]
+          const name = func.name;
+          if (self.options.hooks && self.options.hooks[name]) {
+            const callHook = func;
+            const invoker = function invokeBuiltinHook() {
+              return callHook(options)
+            };
+            responseData.hooks.builtin.push(invoker);
+          }
+        })
+
+        self.done = true;
+        return responseData;
+      })
+  }
+}
+
+
+module.exports = ProcessWorker;

--- a/modules/DocumentConverter/engine/ThreadPool.js
+++ b/modules/DocumentConverter/engine/ThreadPool.js
@@ -1,0 +1,178 @@
+const _private = new WeakMap();
+
+
+class ThreadPool {
+  constructor() {
+    /**
+     * Init a private context
+     */
+    const property = {}
+    const self = this;
+    _private.set(this, property);
+
+    /**
+     * @type {Number<Int>}
+     * @private
+     */
+    _private.get(this).limit = Infinity;
+
+    /**
+     * @type {Function[]}
+     * @private
+     */
+    _private.get(this).threads = [];
+
+    /**
+     * @type {?ThreadPool}
+     * @private
+     */
+    _private.get(this).next = null;
+
+    /**
+     * @type {?Function}
+     * @private
+     * @callback {ThreadPool~doAfter}
+     * @param {?Array} fulfilled - Return values of Promise.all
+     */
+    _private.get(this).after = null;
+
+    /**
+     * @type {Number<Int>}
+     * @public
+     * @readonly
+     */
+    Object.defineProperty(this, 'size', {
+      enumerable: true,
+      get: function getPoolSize() {
+        return _private.get(self).threads.length;
+      }
+    }) 
+  }
+
+  /**
+   * 
+   * @return {boolean}
+   */
+  isFull() {
+    const length = _private.get(this).threads.length
+    const limit = _private.get(this).limit;
+    return length >= limit;
+  }
+
+  /**
+   * Specify the size limit for Pool
+   * @param {Number<Int>} size
+   */
+  setPoolSize(size) {
+    if (Number.isInteger(size) && size > 0) {
+      _private.get(this).limit = size;
+    }
+    return this;
+  }
+
+  /**
+   * Invoker is considered as a function with no arguments, 
+   * used to wake up another function and return its result.
+   * @example
+   * ```javascript
+   * ThreadPool.addInvoker(function threadExample() {
+   *   return (async function() {
+   *     return 'Hello world';
+   *   });
+   * })
+   * ```
+   * @param {Function} invoker
+   */
+  addInvoker(invoker) {
+    if (typeof invoker !== 'function')
+      throw new Error('Invoker must be a function');
+    if (this.isFull())
+      throw new Error('This pool has reached the maximum size')
+
+    _private.get(this).threads.push(invoker);
+    return this;
+  }
+
+  /**
+   * Take an invoker out of the pool
+   * @param {Number|Function} invoker - Index of that invoker, or itself
+   * @return {?Function} - The removed invoker 
+   */
+  takeoutInvoker(invoker) {
+    const threads = _private.get(self).threads;
+
+    if (Number.isInteger(invoker)) {
+      const index = invoker;
+      if (threads[index]) {
+        return threads.splice(index, 1);
+      }
+    }
+    else if (threads.includes(invoker)) {
+      const index = threads.findIndex(invoker);
+      return threads.splice(index, 1);
+    }
+  }
+
+  /**
+   * Do something after the current pool thread ended.
+   * @param {ThreadPool~doAfter} callback - A callback takes an argument is the fulfilled
+   * value of this promise pool.
+   */
+  setAfter(callback) {
+    if (typeof callback == 'function') {
+      _private.get(this).after = async function (fulfilled) {
+        return callback(fulfilled);
+      };
+    }
+
+    return this;
+  }
+
+  /**
+   * Set next pool.
+   * @param {ThreadPool} pool
+   */
+  setNext(pool) {
+    if (pool instanceof ThreadPool) {
+      _private.get(this).next = pool;
+    }
+
+    return this
+  }
+
+  /**
+   * Asynchronously execute processes.
+   * @return {Promise}
+   */
+  run() {
+    const self = this;
+    const threads = _private.get(self).threads;
+
+    return new Promise((resolve, reject) => {
+      Promise.all(threads.map(invoke => invoke()))
+        .then(fulfilled => {
+          let result = fulfilled;
+
+          if (typeof _private.get(self).after == 'function')
+            _private.get(self).after(result).then(res => {
+              if (_private.get(self).next instanceof ThreadPool)
+                resolve(_private.get(self).next.run())
+              else
+                resolve(res);
+            });
+          else {
+            if (_private.get(self).next instanceof ThreadPool)
+              resolve(_private.get(self).next.run())
+            else
+              resolve(result);
+          }
+        })
+        .catch(error => {
+          reject(error);
+        });
+
+    })
+  }
+}
+
+module.exports = ThreadPool;

--- a/modules/DocumentConverter/engine/adapters/converters/PDFConvertAdapter.js
+++ b/modules/DocumentConverter/engine/adapters/converters/PDFConvertAdapter.js
@@ -1,0 +1,171 @@
+const LinkableCommand = require('../../LinkableCommand');
+const PDFInfo = require('../../../util/info');
+
+const _private = new WeakMap()
+
+
+class PDFConvertAdapter {
+  constructor(configurator) {
+    /**
+     * Init a private context
+     */
+    const property = {}
+    const self = this;
+    _private.set(this, property);
+
+    _private.get(this).configurator = configurator;
+    _private.get(this).builder = null;
+    _private.get(this).source = null;
+    _private.get(this).dest = null;
+    _private.get(this).info = null;
+    _private.get(this).options = {};
+    _private.get(this).adapt = {};
+    _private.get(this).fromPage = null;
+    _private.get(this).toPage = null;
+
+    /**
+     * Define readonly property
+     * @private
+     */
+    _private.get(this).setReadOnly = (owner, property) => {
+      Object.defineProperty(self, property, {
+        enumerable: true,
+        get: () => owner[property]
+      })
+    }
+
+    _private.get(this).adapt.dpi = function(builder, info, dpi) {
+      if (typeof builder.setDPI == 'function' && dpi != 'original') {
+        builder.setDPI(dpi);
+      }
+    }
+
+    _private.get(this).adapt.width = function(builder, info, width) {
+      const pageWidth = info.pageSize.width / 0.47967767929089444; // A4 to px
+      
+      if (width.toString().endsWith('%')) {
+        const rate = parseFloat(width.slice(0, -1));
+        width = parseInt(pageWidth * (rate / 100))
+      }
+
+      if (typeof builder.setHorizontalScale == 'function' && width != 'original') {
+        const scale = width / pageWidth;
+        builder.setHorizontalScale(scale.toFixed(2));
+      }
+      else if (typeof builder.setWidth == 'function' && width != 'original') {
+        builder.setWidth(parseInt(width))
+      }
+    }
+
+    _private.get(this).adapt.height = function(builder, info, height) {
+      const pageHeight = info.pageSize.height / 0.47967767929089444; // A4 to px
+
+      if (height.toString().endsWith('%')) {
+        const rate = parseFloat(height.slice(0, -1));
+        height = parseInt(pageHeight * (rate / 100))
+      }
+
+      if (typeof builder.setVerticalScale == 'function' && height != 'original') {
+        const scale = height / pageHeight;
+        builder.setVerticalScale(scale.toFixed(2));
+      }
+      else if (typeof builder.setHeight == 'function' && height != 'original') {
+        builder.setHeight(parseInt(height))
+      }
+    }
+
+    _private.get(this).adapt.fromPage = function(builder, info, page) {
+      if (typeof page == 'number' && typeof builder.convertFromPage == 'function') {
+        builder.convertFromPage(page)
+      }
+      if (typeof page == 'number' && typeof builder.setSpecifiedPage == 'function') {
+        builder.setSpecifiedPage(page)
+      }
+    }
+
+    _private.get(this).adapt.toPage = function(builder, info, page) {
+      if (typeof page == 'number' && typeof builder.convertToPage == 'function') {
+        builder.convertToPage(page)
+      }
+    }
+
+    _private.get(this).setReadOnly(_private.get(this), 'configurator');
+    _private.get(this).setReadOnly(_private.get(this), 'builder');
+    _private.get(this).setReadOnly(_private.get(this), 'source');
+    _private.get(this).setReadOnly(_private.get(this), 'dest');
+    _private.get(this).setReadOnly(_private.get(this), 'options');
+  }
+
+  setBuilder(builder) {
+    _private.get(this).builder = builder;
+    return this;
+  }
+
+  setInput(source) {
+    _private.get(this).source = source;
+    return this;
+  }
+
+  setOutput(dest) {
+    _private.get(this).dest = dest;
+    return this;
+  }
+
+  setOptions(options) {
+    _private.get(this).options = options;
+    return this;
+  }
+
+  setInfo(info) {
+    _private.get(this).info = info;
+    return this;
+  }
+
+  fromPage(page) {
+    _private.get(this).fromPage = page;
+    return this;
+  }
+
+  toPage(page) {
+    _private.get(this).toPage = page;
+    return this;
+  }
+
+  async getExecutable(build_options = {}) {
+    const Builder = _private.get(this).builder;
+    const configurator = _private.get(this).configurator;
+    const options = _private.get(this).options;
+    const input = _private.get(this).source;
+    const output = _private.get(this).dest;
+    const builder = new Builder(options)
+      .setInputExtension(options.inputExtension)
+      .setOutputExtension(options.outputExtension);
+
+    if (!_private.get(this).info) {
+      _private.get(this).info = await PDFInfo.getDocumentInfo(this.source);
+    }
+    
+    const info = _private.get(this).info;
+
+    // use configurator to config builder here
+    Object.keys(configurator).forEach(key => {
+      if (key == 'dpi')
+        _private.get(this).adapt.dpi(builder, info, configurator.dpi);
+      if (key == 'width')
+        _private.get(this).adapt.width(builder, info, configurator.width);
+      if (key == 'height')
+        _private.get(this).adapt.height(builder, info, configurator.height);
+    });
+
+    if (_private.get(this).fromPage)
+      _private.get(this).adapt.fromPage(builder, info, _private.get(this).fromPage);
+    if (_private.get(this).toPage)
+      _private.get(this).adapt.toPage(builder, info, _private.get(this).toPage);
+
+    const command = builder.build(input, output, { returnString: true, addOutputExtension: true, ...build_options });
+    return new LinkableCommand(command);
+  }
+}
+
+
+module.exports = PDFConvertAdapter;

--- a/modules/DocumentConverter/engine/adapters/splitters/PDFSplitAdapter.js
+++ b/modules/DocumentConverter/engine/adapters/splitters/PDFSplitAdapter.js
@@ -1,0 +1,75 @@
+const LinkableCommand = require('../../LinkableCommand');
+
+const _private = new WeakMap();
+
+
+class PDFSplitAdapter {
+  constructor(configurator) {
+    /**
+     * Init a private context
+     */
+    const property = {}
+    const self = this;
+    _private.set(this, property);
+
+    _private.get(this).configurator = configurator;
+    _private.get(this).builder = null;
+    _private.get(this).source = null;
+    _private.get(this).dest = null;
+    _private.get(this).options = {};
+
+    /**
+     * Define readonly property
+     * @private
+     */
+    _private.get(this).setReadOnly = (owner, property) => {
+      Object.defineProperty(self, property, {
+        enumerable: true,
+        get: () => owner[property]
+      })
+    }
+
+    _private.get(this).setReadOnly(_private.get(this), 'configurator');
+    _private.get(this).setReadOnly(_private.get(this), 'builder');
+    _private.get(this).setReadOnly(_private.get(this), 'source');
+    _private.get(this).setReadOnly(_private.get(this), 'dest');
+    _private.get(this).setReadOnly(_private.get(this), 'options');
+  }
+
+  setBuilder(builder) {
+    _private.get(this).builder = builder;
+    return this;
+  }
+
+  setInput(source) {
+    _private.get(this).source = source;
+    return this;
+  }
+
+  setOutput(dest) {
+    _private.get(this).dest = dest;
+    return this;
+  }
+
+  setOptions(options) {
+    _private.get(this).options = options;
+    return this;
+  }
+
+  getExecutable() {
+    const Builder = _private.get(this).builder;
+    const configurator = _private.get(this).configurator;
+    const options = _private.get(this).options;
+    const input = _private.get(this).source;
+    const output = _private.get(this).dest;
+    const builder = new Builder(options);
+
+    // use configurator to config builder here 
+
+    const command = builder.build(input, output, { returnString: true });
+    return new LinkableCommand(command);
+  }
+}
+
+
+module.exports = PDFSplitAdapter;

--- a/modules/DocumentConverter/engine/hooks/AfterSession.js
+++ b/modules/DocumentConverter/engine/hooks/AfterSession.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+
+
+module.exports = [];
+
+
+/**
+ * Callback hook for resolve bad naming after every session
+ * @param {Object} context - Shared context
+ */
+module.exports.push(function resolveBadNaming(context) {
+  const output_folder = context.output;
+  if (!fs.existsSync(output_folder)) return;
+
+  const output_files = fs.readdirSync(output_folder);
+  const bad_naming = [
+    {
+      regex: /^[0-9]+\.[A-z]{1,5}\-[0-9]+\.[A-z]/, // e.g: 22.png-1.png
+      solution: name => name.split('-').shift().trim()
+    },
+    { 
+      regex: /^\-[0-9]+\.[A-z]{1,5}$/, 
+      solution: name => name.trim().slice(1)      // e.g: -22.png
+    }
+  ]
+
+  output_files.forEach(file => {
+    const bad_case = bad_naming.find(_case => _case.regex.test(file));
+
+    if (bad_case) {
+      const better_named_file = bad_case.solution(file);
+      const oldpath = path.resolve(output_folder, file);
+      const newpath = path.resolve(output_folder, better_named_file);
+      fs.renameSync(oldpath, newpath);
+      console.log(`Resolve bad naming "${file}" to "${better_named_file}" at folder: ${output_folder}`)
+    }
+  });
+})
+
+
+/**
+ * Delete cached folder after every session
+ * @param {Object} context - Shared context
+ */
+module.exports.push(function clearCache(context) {
+  const cached_folder = context.cache;
+
+  if (fs.existsSync(cached_folder)) {
+    fs.rmdirSync(cached_folder, { recursive: true });
+    console.log(`Cache removed: ${cached_folder}`);
+  }
+})

--- a/modules/DocumentConverter/index.js
+++ b/modules/DocumentConverter/index.js
@@ -1,0 +1,3 @@
+module.exports.ConvertEngine = require('./ConvertEngine');
+module.exports.ConvertConfigurator = require('./ConvertConfigurator');
+module.exports.PDFInfo = require('./util/info');

--- a/modules/DocumentConverter/util/info/PDFDocumentInfo.js
+++ b/modules/DocumentConverter/util/info/PDFDocumentInfo.js
@@ -1,0 +1,67 @@
+const PDFPresenter = require('./PDFPresenter');
+const PopplerExtractor = require('./extractor/Poppler_PDFInfoExtractor');
+
+
+/**
+ * @param {string} field
+ * @param {Array} extractors
+ */
+const getFieldValue = function getFieldValue(field, extractors) {
+  const getField = 'get' + field.charAt(0).toUpperCase() + field.slice(1);
+  const isField = 'is' + field.charAt(0).toUpperCase() + field.slice(1);
+
+  for (const extractor of extractors) {
+    const isFieldGetter = typeof extractor[getField] == 'function';
+
+    try {
+      let value = isFieldGetter ? extractor[getField]() : extractor[isField]();
+      return value;
+    }
+    catch {
+      continue;
+    }
+  }
+}
+
+
+class PDFDocumentInfo {
+  constructor() {
+    this.havingPoppler = false;
+    this.extractors = [];
+  }
+
+  provideOriginalFile(file) {
+    const poppler = new PopplerExtractor(file);
+    this.extractors.push(poppler);
+    return this;
+  }
+
+  setPresenter(presenter) {
+    if (PDFPresenter.isPresenter(presenter)) {
+      this.extractors.push(presenter);
+    }
+    return this;
+  }
+
+  getMetadataFieldNames() {
+    return [
+      'title', 'author', 'creator', 'subject', 'producer', 'keywords',
+      'pageCount', 'pageIndices', 'creationDate', 'modificationDate',
+      'PDFVersion', 'compressed', 'encrypted', 'pageSize', 'fileSize'
+    ];
+  }
+
+  getInfo() {
+    const fields = this.getMetadataFieldNames();
+    const info = Object.create(null);
+
+    for (const field of fields) {
+      info[field] = getFieldValue(field, this.extractors);
+    }
+
+    return info;
+  }
+}
+
+
+module.exports = PDFDocumentInfo;

--- a/modules/DocumentConverter/util/info/PDFInfo.js
+++ b/modules/DocumentConverter/util/info/PDFInfo.js
@@ -1,0 +1,41 @@
+const PDFValidator = require('./PDFValidator');
+const PDFPresenter = require('./PDFPresenter');
+const PDFDocumentInfo = require('./PDFDocumentInfo');
+
+
+class PDFInfo {
+  /**
+   * @param {Buffer|PDFDocument|string} pdf - PDF Buffer, PDFDocument or path
+   * @return {pdflib.PDFDocument}
+   */
+  static async getPresenter(pdf) {
+    return PDFPresenter.create(pdf);
+  }
+
+  /**
+   * @param {Buffer|string} pdf - PDF Buffer or path
+   * @return {boolean}
+   */ 
+  static isPDF(pdf) {
+    return PDFValidator.isPDF(pdf);
+  }
+
+  /**
+   * @param {Buffer|PDFDocument|string} pdf - PDF Buffer, PDFDocument or path
+   * @return {Object}
+   */
+  static async getDocumentInfo(pdf) {
+    const presenter = await this.getPresenter(pdf);
+
+    let PDFInfoGetter = new PDFDocumentInfo();
+
+    if (typeof pdf == 'string' && this.isPDF(pdf)) {
+      PDFInfoGetter = PDFInfoGetter.provideOriginalFile(pdf);
+    }
+
+    return PDFInfoGetter.setPresenter(presenter).getInfo();
+  }
+}
+
+
+module.exports = PDFInfo;

--- a/modules/DocumentConverter/util/info/PDFPresenter.js
+++ b/modules/DocumentConverter/util/info/PDFPresenter.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const pdflib = require('pdf-lib');
+const PDFInvalidDocumentError = require('./errors/PDFInvalidDocumentError');
+
+
+class PDFPresenter {
+  static async create(pdf) {
+    if (this.isPresenter(pdf)) return pdf;
+    PDFInvalidDocumentError.THROW_IF_NOT_A_PDF_DOCUMENT(pdf);
+
+    if (Buffer.isBuffer(pdf)) {
+      return await pdflib.PDFDocument.load(pdf);
+    }
+    else if (pdf instanceof fs.ReadStream) {
+      const stream = pdf;
+      return this.create(stream.path);
+    }
+    else if (typeof pdf == 'string') {
+      const buf = fs.readFileSync(pdf);
+      return this.create(buf);
+    }
+  }
+
+  static isPresenter(pdf) {
+    if (pdf instanceof pdflib.PDFDocument) {
+      return true;
+    }
+  }
+}
+
+
+module.exports = PDFPresenter;

--- a/modules/DocumentConverter/util/info/PDFValidator.js
+++ b/modules/DocumentConverter/util/info/PDFValidator.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const pdflib = require('pdf-lib');
+const PDFDocumentError = require('./errors/PDFDocumentError');
+
+
+class PDFValidator {
+  static isPDF(pdf) {
+    if (pdf instanceof pdflib.PDFDocument) {
+      return true;
+    }
+    if (Buffer.isBuffer(pdf)) {
+      const buf = pdf;
+      return buf.lastIndexOf('%PDF-') === 0 && buf.lastIndexOf('%%EOF') > -1;
+    }
+    else if (pdf instanceof fs.ReadStream) {
+      const stream = pdf;
+      return this.isPDF(stream.path);
+    }
+    else if (typeof pdf === 'string') {
+      const file = path.resolve(pdf);
+      PDFDocumentError.THROW_IF_NOT_A_FILE(file);
+
+      const buf = Buffer.alloc(5);
+      const descriptor = fs.openSync(file, 'r');
+      const bytesLength = fs.readSync(descriptor, buf, { length: 5 });
+      const trbuf = bytesLength < 5 ? buf.slice(0, bytesLength) : buf;
+      fs.closeSync(descriptor)
+      return trbuf.lastIndexOf('%PDF-') === 0;
+    }
+    return false;
+  }
+}
+
+
+module.exports = PDFValidator;

--- a/modules/DocumentConverter/util/info/errors/PDFCommandError.js
+++ b/modules/DocumentConverter/util/info/errors/PDFCommandError.js
@@ -1,0 +1,13 @@
+const child_process = require('child_process');
+const PDFThrowable = require('./PDFThrowable');
+
+
+class PDFCommandError extends PDFThrowable {
+  static THROW_IF_COMMAND_NOT_EXIST(command) {
+    if (!child_process.execSync(`command -v ${command} | xargs`).toString().trim())
+      throw new this(`Not a command: ${command}`);
+  }
+}
+
+
+module.exports = PDFCommandError;

--- a/modules/DocumentConverter/util/info/errors/PDFDocumentError.js
+++ b/modules/DocumentConverter/util/info/errors/PDFDocumentError.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const PDFThrowable = require('./PDFThrowable');
+
+
+class PDFDocumentError extends PDFThrowable {
+  /**
+   * @param {string} file
+   */
+  static THROW_IF_FILE_NOT_FOUND(file) {
+    const exists = file && fs.existsSync(file);
+    if (!exists) throw new this(`File not found: ${file}`);
+  }
+
+  /**
+   * @param {string} file
+   */
+  static THROW_IF_NOT_A_FILE(file) {
+    this.THROW_IF_FILE_NOT_FOUND(file);
+
+    if (!fs.statSync(file).isFile())
+      throw new this(`Not a file: ${file}`)
+  }
+}
+
+
+module.exports = PDFDocumentError;

--- a/modules/DocumentConverter/util/info/errors/PDFInvalidDocumentError.js
+++ b/modules/DocumentConverter/util/info/errors/PDFInvalidDocumentError.js
@@ -1,0 +1,13 @@
+const PDFThrowable = require('./PDFThrowable');
+const PDFValidator = require('../PDFValidator');
+
+
+class PDFInvalidDocumentError extends PDFThrowable {
+  static THROW_IF_NOT_A_PDF_DOCUMENT(file) {
+    if (!PDFValidator.isPDF(file))
+      throw new this(`Not a PDF document: ${file}`);
+  }
+}
+
+
+module.exports = PDFInvalidDocumentError;

--- a/modules/DocumentConverter/util/info/errors/PDFThrowable.js
+++ b/modules/DocumentConverter/util/info/errors/PDFThrowable.js
@@ -1,0 +1,9 @@
+class PDFThrowable extends Error {
+  constructor(message, ...stack) {
+    super(message);
+    this.name = this.constructor.name;    
+    this.stack = stack.map(line => '?> ' + line).join('\n') + `\n${this.stack}`;
+  }
+};
+
+module.exports = PDFThrowable;

--- a/modules/DocumentConverter/util/info/extractor/Poppler_PDFInfoExtractor.js
+++ b/modules/DocumentConverter/util/info/extractor/Poppler_PDFInfoExtractor.js
@@ -1,0 +1,71 @@
+const child_process = require('child_process');
+const PDFDocumentError = require('../errors/PDFDocumentError');
+const PDFCommandError = require('../errors/PDFCommandError');
+
+
+function extractInfo(property) {
+  const matchedLine = this.find(line => line.startsWith(`${property}:`));
+  if (matchedLine)
+    return matchedLine.split(`${property}:`).pop().trim();
+}
+
+const TypeConvertion = {
+  toDate: value => new Date(value),
+  toNumber: value => Number(value),
+  toBoolean: value => ['true', 'yes'].includes(value.toString().toLowerCase()) ? true
+    : ['false', 'no'].includes(value.toString().toLowerCase()) ? false
+    : value.toString(),
+}
+
+
+/**
+ * @hideconstructor
+ */
+module.exports = function Poppler_PDFInfoExtractor(file) {
+  PDFDocumentError.THROW_IF_NOT_A_FILE(file);
+  PDFCommandError.THROW_IF_COMMAND_NOT_EXIST('pdfinfo');
+
+  const info = child_process.execSync(`pdfinfo "${file}"`).toString();
+  const infoAsArray = info.split('\n');
+  const getFieldValue = extractInfo.bind(infoAsArray);
+
+  class Poppler_PDFInfo {
+    constructor() {
+      this.path = file;
+      this.info = info;
+    }
+
+    getTitle = () => getFieldValue('Title')
+    getAuthor = () => getFieldValue('Author')
+    getCreator = () => getFieldValue('Creator')
+    getSubject = () => getFieldValue('Subject')
+    getProducer = () => getFieldValue('Producer')
+    getKeywords = () => getFieldValue('Keywords')
+    getCreationDate = () => TypeConvertion.toDate(getFieldValue('CreationDate'))
+    getModificationDate = () => TypeConvertion.toDate(getFieldValue('ModDate'))
+    getPageCount = () => TypeConvertion.toNumber(getFieldValue('Pages'))
+    getPDFVersion = () => TypeConvertion.toNumber(getFieldValue('PDF version'))
+    isCompressed = () => TypeConvertion.toBoolean(getFieldValue('Optimized'))
+    isEncrypted = () => TypeConvertion.toBoolean(getFieldValue('Encrypted'))
+
+    getPageSize = function getPageWidth() {
+      const str = getFieldValue('Page size');
+      const re = /^([0-9\.]+)\s+x\s+([0-9\.]+)/;
+      const match = str.match(re);
+      let width, height, size = {};
+
+      if (match && match.length >= 3) {
+        [ width, height ] = match.slice(1, 3);
+        size = { 
+          width: TypeConvertion.toNumber(width), 
+          height: TypeConvertion.toNumber(height) 
+        };
+      }
+      return size; 
+    }
+
+    getFileSize = () => TypeConvertion.toNumber(getFieldValue('File size').split(/\s+/).shift())
+  }
+
+  return new Poppler_PDFInfo;
+}

--- a/modules/DocumentConverter/util/info/index.js
+++ b/modules/DocumentConverter/util/info/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./PDFInfo');

--- a/package.json
+++ b/package.json
@@ -18,23 +18,34 @@
     "dev": "npx nodemon server.js",
     "test": "ava",
     "dbbackup": "mysqldump --single-transaction -u publicuser -p pdf2fdp_test --result-file=./database/backup.sql",
-    "dbdrop-dev": "sudo mysql < database/query/drop-all.sql"
+    "dbdrop-dev": "sudo mysql < database/query/drop-all.sql",
+    "circular": "madge --circular"
   },
   "dependencies": {
+    "bluebird": "^3.7.2",
     "dotenv": "^10.0.0",
     "express": "^4.17.2",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",
     "mysql2": "^2.3.3",
+    "pdf-lib": "^1.17.1",
     "sequelize": "^6.12.0",
     "xregexp": "^5.1.0"
   },
   "devDependencies": {
     "ava": "^3.15.0",
+    "axios": "^0.24.0",
+    "detect-svg": "^0.9.1",
+    "madge": "^5.0.1",
     "nodemon": "^2.0.15",
     "sequelize-cli": "^6.3.0"
   },
   "ava": {
-    "snapshotDir": "test/snapshots/"
+    "snapshotDir": "test/snapshots/",
+    "concurrency": 1,
+    "failFast": true,
+    "failWithoutAssertions": false,
+    "verbose": true,
+    "timeout": "2m"
   }
 }

--- a/test/convert.js
+++ b/test/convert.js
@@ -1,0 +1,590 @@
+const fs = require('fs');
+const path = require('path');
+const ava = require('ava');
+const axios = require('axios');
+const pdflib = require('pdf-lib');
+const child_process = require('child_process');
+const detectSVG = require('detect-svg');
+const init = require('./init');
+const env = require('../config').env.parsed;
+
+init.useDefaultHooks();
+
+const testspace = `${env.ENTRY_MODULES}/DocumentConverter`;
+
+
+const local = {
+  builder: {
+    PDFConv: require(`${testspace}/builder/converters/PDFConverterBuilder`),
+    PDF2PPM: require(`${testspace}/builder/converters/PDF2PPM_Builder`),
+    PDF2SVG: require(`${testspace}/builder/converters/PDF2SVG_Builder`),
+    PDFTK: require(`${testspace}/builder/splitters/PDFTK_Builder`),
+  },
+  convert: {
+    ConvertEngine: require(`${testspace}/ConvertEngine`),
+    ConvertConfigurator: require(`${testspace}/ConvertConfigurator`),
+  },
+  util: {
+    PDFInfo: require(`${testspace}/util/info`),
+  },
+  prepared: {
+    node4prof: {
+      url: 'http://books.goalkicker.com/NodeJSBook/NodeJSNotesForProfessionals.pdf',
+      file: `${__dirname}/convert/node4prof/NodeJSNotesForProfessionals.pdf`,
+      buffer: null,
+      readStream: null,
+      presenter: null,
+      info: null,
+      env: {
+        root: `${__dirname}/convert/node4prof`,
+        pdf: `${__dirname}/convert/node4prof/pdf`,
+        svg: `${__dirname}/convert/node4prof/svg`,
+        png: `${__dirname}/convert/node4prof/png`,
+      }
+    },
+    cleancode: {
+      url: 'https://raw.githubusercontent.com/ontiyonke/book-1/master/%5BPROGRAMMING%5D%5BClean%20Code%20by%20Robert%20C%20Martin%5D.pdf',
+      file: `${__dirname}/convert/cleancode/CleanCode.pdf`,
+      buffer: null,
+      readStream: null,
+      presenter: null,
+      info: null,
+      env: {
+        root: `${__dirname}/convert/cleancode`,
+        pdf: `${__dirname}/convert/cleancode/pdf`,
+        svg: `${__dirname}/convert/cleancode/svg`,
+        png: `${__dirname}/convert/cleancode/png`,
+      }
+    }
+  },
+  func: {
+    downloadFile: async function downloadFile(url, dest) {
+      const writeStream = fs.createWriteStream(dest);
+      const response = await axios({
+        method: 'get',
+        url: url,
+        responseType: 'stream'
+      })
+      response.data.pipe(writeStream);
+      
+      return new Promise((resolve, reject) => {
+        response.data.on('end', () => resolve());
+        response.data.on('error', error => {
+          test.fail('0. Download sample PDF file error. Check your internet connection.');
+          reject(error)
+        });
+      })
+    },
+    isPNG: function isPNG(buffer) {
+      if (!buffer || buffer.length < 8) {
+        return false;
+      }
+
+      return buffer[0] === 0x89
+        && buffer[1] === 0x50
+        && buffer[2] === 0x4E
+        && buffer[3] === 0x47
+        && buffer[4] === 0x0D
+        && buffer[5] === 0x0A
+        && buffer[6] === 0x1A
+        && buffer[7] === 0x0A;
+    }
+  }
+};
+
+
+ava.before('preparation: download sample pdf document if not exists', async function downloadSamplePDFDocument(test) {
+  const dirs = Object.values(local.prepared.node4prof.env)
+    .concat(Object.values(local.prepared.cleancode.env));
+  dirs.forEach(dir => !fs.existsSync(dir) && fs.mkdirSync(dir));
+
+  const downloadFile = local.func.downloadFile;
+
+  const node4prof = {
+    url: local.prepared.node4prof.url,
+    dest: local.prepared.node4prof.file,
+  }
+
+  const cleancode = {
+    url: local.prepared.cleancode.url,
+    dest: local.prepared.cleancode.file,
+  }
+
+  /**
+   * Use only one engine to ensure synchronization
+   */
+  const ConvertEngine = local.convert.ConvertEngine;
+  local.convert.ConvertEngine = new ConvertEngine();
+
+  test.plan(2);  
+
+  if (!fs.existsSync(node4prof.dest)) {
+    await downloadFile(node4prof.url, node4prof.dest);
+    local.prepared.node4prof.buffer = fs.readFileSync(local.prepared.node4prof.file);
+    local.prepared.node4prof.readStream = fs.createReadStream(local.prepared.node4prof.file);
+  }
+  else {
+    test.is(true, true)
+    local.prepared.node4prof.buffer = fs.readFileSync(local.prepared.node4prof.file);
+    local.prepared.node4prof.readStream = fs.createReadStream(local.prepared.node4prof.file);
+  }
+
+  if (!fs.existsSync(cleancode.dest)) {
+    await downloadFile(cleancode.url, cleancode.dest);
+    local.prepared.cleancode.buffer = fs.readFileSync(local.prepared.cleancode.file);
+    local.prepared.cleancode.readStream = fs.createReadStream(local.prepared.cleancode.file);
+  }
+  else {
+    test.is(true, true)
+    local.prepared.cleancode.buffer = fs.readFileSync(local.prepared.cleancode.file);
+    local.prepared.cleancode.readStream = fs.createReadStream(local.prepared.cleancode.file);
+  }
+});
+
+
+ava.serial('test case: check whether the conversion tools and dependencies installed or not', async function checkConvertDependenciesInstalled(test) {
+  const missingTools = [];
+  try {
+    const conversionTools = ['pdfinfo', 'pdftoppm', 'pdf2svg', 'pdftk'];
+
+    test.plan(conversionTools.length);
+
+    for (const tool of conversionTools) {
+      if (child_process.execSync(`command -v ${tool} | xargs`).toString().trim()) {
+        test.pass();
+        continue;
+      }
+      test.log(`This tool is not installed: ${tool}`);
+      missingTools.push(tool);
+    }
+  }
+  catch (error) {
+    test.fail(`1. These tools are not installed: ${missingTools.join(', ')}`)
+    test.log(error);
+  }
+});
+
+
+ava.serial('test case: test command builder PDFConverterBuilder', async function testPDFConverterBuilder(test) {
+  try {
+    const PDFConverterBuilder = local.builder.PDFConv;
+
+    const plans = [
+      {
+        expected: ['cp', '~/Downloads/sample.pdf', '~/Downloads/'].join(' '),
+        actually: new PDFConverterBuilder({ testing: 'ava' })
+          .setOutputExtension('pdf')
+          .build('~/Downloads/sample.pdf', '~/Downloads/', { returnString: true })
+      },
+      {
+        expected: ['~/Downloads/sample.pdf', '~/Downloads/'].join(' '),
+        actually: new PDFConverterBuilder({ testing: 'ava' })
+          .build('~/Downloads/sample.pdf', '~/Downloads/', { returnString: true })
+      },
+    ];
+
+    test.plan(plans.length);
+
+    for (const { expected, actually } of plans) {
+      test.deepEqual(actually, expected);
+    }
+  }
+  catch (error) {
+    test.fail('2. PDFConverterBuilder ancestor builder does not return expected results.');
+    test.log(error);
+  }
+})
+
+
+ava.serial('test case: test command builder PDF2PPM', async function testSubmodPDF2PPM(test) {
+  try {
+    const PDF2PPM = local.builder.PDF2PPM;
+
+    const plans = [
+      {
+        expected: ['pdftoppm', '-png', '-r', 300, '-scale-to-y', 1000, '~/Downloads/sample.pdf', '~/Downloads/'].join(' '),
+        actually: new PDF2PPM({ testing: 'ava' })
+          .setOutputExtension('png')
+          .setDPI(300)
+          .setHeight(1000)
+          .build('~/Downloads/sample.pdf', '~/Downloads/', { returnString: true })
+      },
+      {
+        expected: ['pdftoppm', '-jpg', '~/Downloads/sample.pdf', '~/Downloads/'].join(' '),
+        actually: new PDF2PPM({ testing: 'ava' })
+          .setOutputExtension('jpg')
+          .build('~/Downloads/sample.pdf', '~/Downloads/', { returnString: true })
+      }
+    ];
+
+    test.plan(plans.length);
+
+    for (const { expected, actually } of plans) {
+      test.deepEqual(actually, expected);
+    }
+  }
+  catch (error) {
+    test.fail('3. PDF2PPM builder does not return expected results.');
+    test.log(error);
+  }
+})
+
+
+ava.serial('test case: test command builder PDF2SVG', async function testSubmodPDF2SVG(test) {
+  try {
+    const PDF2SVG = local.builder.PDF2SVG;
+
+    const plans = [
+      {
+        expected: ['pdf2svg', '~/Downloads/sample.pdf', '~/Downloads/sample.svg'].join(' '),
+        actually: new PDF2SVG({ testing: 'ava' }).build('~/Downloads/sample.pdf', '~/Downloads/', { returnString: true })
+      }
+    ];
+
+    test.plan(plans.length);
+
+    for (const { expected, actually } of plans) {
+      test.deepEqual(actually, expected);
+    }
+  }
+  catch (error) {
+    test.fail('4. PDF2SVG builder does not return expected results.')
+    test.log(error);
+  }
+})
+
+
+ava.serial('test case: test command builder PDFTK', async function testSubmodPDFTK(test) {
+  try {
+    const PDFTK = local.builder.PDFTK;
+
+    const plans = [
+      {
+        expected: ['pdftk', '~/Downloads/sample.pdf', 'burst output', '~/Downloads/%d.pdf'].join(' '),
+        actually: new PDFTK({ testing: 'ava' })
+          .build('~/Downloads/sample.pdf', '~/Downloads/', { returnString: true }),
+      },
+      {
+        expected: ['pdftk', '~/Downloads/sample.pdf', 'burst output', '~/Downloads/sample_%d.pdf'].join(' '),
+        actually: new PDFTK({ testing: 'ava' })
+          .build('~/Downloads/sample.pdf', '~/Downloads/sample', { returnString: true }),
+      }
+    ];
+
+    test.plan(plans.length);
+
+    for (const { expected, actually } of plans) {
+      test.deepEqual(actually, expected);
+    }
+  }
+  catch (error) {
+    test.fail('5. PDF2TK builder does not return expected results.')
+    test.log(error);
+  }
+})
+
+
+ava.serial('test case: test return of the method PDFInfo.getPresenter()', async function testPDFPresenterReturn(test) {
+  try {
+    const file = local.prepared.node4prof.file;
+    const buffer = local.prepared.node4prof.buffer;
+    const readableStream = local.prepared.node4prof.readStream;
+    
+    const plans = [
+      // Test if the given argument is a Buffer
+      {
+        expected: pdflib.PDFDocument,
+        actually: await local.util.PDFInfo.getPresenter(buffer)
+      },
+      // Test if the given argument is a ReadableStream
+      {
+        expected: pdflib.PDFDocument,
+        actually: await local.util.PDFInfo.getPresenter(readableStream)
+      },
+      // Test if the given argument is a Path
+      {
+        expected: pdflib.PDFDocument,
+        actually: await local.util.PDFInfo.getPresenter(file)
+      }
+    ]
+
+    test.plan(plans.length + 1)
+
+    for (const { expected, actually } of plans) {
+      test.notDeepEqual(actually, expected);
+    } 
+
+    local.prepared.node4prof.presenter = await local.util.PDFInfo.getPresenter(buffer);
+    test.pass()
+  }
+  catch (error) {
+    test.fail('6. An error occurred, re-check method PDFInfo.getPresenter()');
+    test.log(error);
+  }
+})
+
+
+ava.serial('test case: test method PDFInfo.isPDF()', async function testPDFInfoRecognize(test) {
+  try {
+    const file = local.prepared.node4prof.file;
+    const buffer = local.prepared.node4prof.buffer;
+    const readableStream = local.prepared.node4prof.readStream;
+    const presenter = local.prepared.node4prof.presenter;
+
+
+    const plans = [
+      {
+        expected: true,
+        actually: local.util.PDFInfo.isPDF(presenter),
+      },
+      {
+        expected: true,
+        actually: local.util.PDFInfo.isPDF(buffer),
+      },
+      {
+        expected: true,
+        actually: local.util.PDFInfo.isPDF(readableStream),
+      },
+      {
+        expected: true,
+        actually: local.util.PDFInfo.isPDF(file),
+      },
+      {
+        expected: false,
+        actually: local.util.PDFInfo.isPDF(__filename),
+      } 
+    ];
+
+    test.plan(plans.length)
+
+    for (const { expected, actually } of plans) {
+      test.is(actually, expected);
+    }
+  }
+  catch (error) {
+    test.fail('7. An error occurred, re-check method PDFInfo.isPDF()');
+    test.log(error);
+  }
+});
+
+
+ava.serial('test case: check pdf document information getter', async function getPDFDocumentInformation(test) {
+  try {
+    const file = local.prepared.node4prof.file;
+    const presenter = local.prepared.node4prof.presenter;
+
+    const info = await local.util.PDFInfo.getDocumentInfo(file);
+    local.prepared.node4prof.info = info;
+
+    const plans = [
+      {
+        expected: 'Node.js Notes for Professionals',
+        actually: info.title,
+        performTest: test.is,
+      },
+      {
+        expected: 334,
+        actually: info.pageCount,
+        performTest: test.is,
+      },
+      {
+        expected: new Date('Fri May  4 18:10:16 2018 +07'),
+        actually: info.creationDate,
+        performTest: test.deepEqual
+      },
+      {
+        expected: { width: 595.28, height: 841.89 },
+        actually: info.pageSize,
+        performTest: test.deepEqual
+      },
+      {
+        expected: await local.util.PDFInfo.getDocumentInfo(presenter),
+        actually: info,
+        performTest: test.notDeepEqual,
+      }
+    ];
+
+    test.plan(plans.length);
+
+    for (const { expected, actually, performTest } of plans) {
+      performTest(actually, expected);
+    }
+  }
+  catch (error) {
+    test.fail('8. An error occurred while retrieving this document\'s information');
+    test.log(error);
+  }
+});
+
+
+ava.serial('test case: test convert CleanCode to SVG (using default configurator, with single worker)', async function convertDefault(test) {
+  try {
+    const engine = local.convert.ConvertEngine;
+
+    const source = local.prepared.cleancode.file;
+    const dest = local.prepared.cleancode.env.svg;
+
+    const info = await local.util.PDFInfo.getDocumentInfo(source);
+    local.prepared.cleancode.info = info;
+
+    /**
+     * Document settings, like DPI, page size, etc. For default settings, 
+     * all parameter values are `original`.
+     */
+    const configurator = local.convert.ConvertConfigurator.getDefault();
+
+    engine.setMaxConcurrency(1)
+      .addFile(source, dest, {
+        configurator,
+        inputExtension: 'pdf',
+        outputExtension: 'svg',
+        // Default hooks
+        hooks: {
+          // Auto resolve bad naming of output file
+          resolveBadNaming: true,
+          // Clear cache after convert
+          clearCache: true,
+        }
+      });
+
+    test.plan(4);
+
+    /**
+     * `result` is return of a Promise.all (array), containing 
+     * fulfilled values of engines.
+     * Each element is an object consisting of fields:
+     * - `pools` are a collection of fulfilled promises that return ThreadPools.
+     *   By the nature of the engine, each pool consists of many LinkableCommands running in parallel. 
+     *   Each LinkableCommand is a command followed by many other commands. 
+     * - `hooks` are invoker functions (either user-defined or engine-provided) that can 
+     *   be hooked at any point in the conversion progress to interfere with certain situations.
+     */
+    const result = await engine.convert();
+    // For AVA, the timeout of each test case is 10 seconds, which will cause test case skip 
+    // while converting midway.
+
+    const convertedSVGs = fs.readdirSync(local.prepared.cleancode.env.svg);
+    /**
+     * A single conversion session will be limited to 10 processes (for free users). 
+     * In case of 2 or more processes (paid users), it will extend the 
+     * limit to 20 processes (or more in the future).
+     */
+    test.is(result[0].pools.length, 10); 
+    /**
+     * Total number of converted pages must be enough 462 pages
+     */
+    test.is(info.pageCount, 462);
+    test.is(convertedSVGs.length, info.pageCount);
+
+    /**
+     * Check some of them are really SVG?
+     */
+    const SVGfile = path.resolve(local.prepared.cleancode.env.svg, convertedSVGs.pop())
+    const SVGbuffer = fs.readFileSync(SVGfile);
+    test.true(detectSVG(SVGbuffer));
+  }
+  catch (error) {
+    test.fail('9. An error occurred while converting this document to SVG');
+    test.log(error);
+  }
+})
+
+
+ava.serial('test case: test convert NodeJS for Prof to PNG (using custom configurator, with single worker)', 
+  async function convertCustom(test) {
+  try {
+    const engine = local.convert.ConvertEngine;
+
+    const source = local.prepared.node4prof.file;
+    const dest = local.prepared.node4prof.env.png;
+
+    /**
+     * Reuse previous test case
+     */
+    const info = local.prepared.node4prof.info;
+
+    const configurator = local.convert.ConvertConfigurator.fromJSON({
+      width: '50%',
+      height: '50%'
+    });
+
+    engine.setMaxConcurrency(1)
+      .addFile(source, dest, {
+        configurator,
+        inputExtension: 'pdf',
+        outputExtension: 'png',
+        hooks: {
+          resolveBadNaming: true,
+          clearCache: true,
+        }
+      });
+
+    test.plan(4);
+
+    const result = await engine.convert();
+    const convertedPNG = fs.readdirSync(dest);
+
+    test.is(result[0].pools.length, 10); 
+    /**
+     * Total number of converted pages must be enough 334 pages
+     */
+    test.is(info.pageCount, 334);
+    test.is(convertedPNG.length, info.pageCount);
+
+    /**
+     * Check some of them are really PNG?
+     */
+    const PNGfile = path.resolve(dest, convertedPNG.find(file => file.toLowerCase().endsWith('.png')));
+    const PNGbuffer = fs.readFileSync(PNGfile);
+    test.true(local.func.isPNG(PNGbuffer));
+  }
+  catch (error) {
+    test.fail('10. An error occurred while converting this document to PNG');
+    test.log(error);
+  }
+});
+
+
+ava.serial('test case: test convert both at the same time (multiple workers)', async function convertBoth(test) {
+  try {
+    const engine = local.convert.ConvertEngine;
+
+    const node4prof = local.prepared.node4prof;
+    const cleancode = local.prepared.cleancode;
+
+    const configurator = local.convert.ConvertConfigurator.getDefault();
+
+    engine.setMaxConcurrency(2)
+      .addFile(node4prof.file, node4prof.env.svg, {
+        configurator,
+        inputExtension: 'pdf',
+        outputExtension: 'svg',
+        hooks: {
+          resolveBadNaming: true,
+          clearCache: true,
+        }
+      })
+      .addFile(cleancode.file, cleancode.env.png, {
+        configurator,
+        inputExtension: 'pdf',
+        outputExtension: 'png',
+        hooks: {
+          resolveBadNaming: true,
+          clearCache: true,
+        }
+      });
+
+    test.plan(2);
+
+    await engine.convert();
+    const node4profSVGdest = fs.readdirSync(node4prof.env.svg);
+    const cleancodePNGdest = fs.readdirSync(cleancode.env.png);
+
+    test.is(node4profSVGdest.length, node4prof.info.pageCount);
+    test.is(cleancodePNGdest.length, cleancode.info.pageCount);
+  }
+  catch (error) {
+    test.fail('11. An error occurred.');
+    test.log(error);
+  }
+});


### PR DESCRIPTION
This PR implements convert module, one of the most important backend components of this project. It is built in a way that is separate from the system, acts as an independent service, for easy maintenance or expansion of new features in the future.
Currently support convert from PDF to SVG, PNG, JPEG, TIFF

## What does it have? 
Currently this module exporting 3 classes:
- **ConvertEngine**: Take the role of receiving and performing file conversion based on external requests. It mainly contains the following methods:
    - `addFile()`: Add files to convert list.
    - `convert()`: Convert the added files.
    - `setMaxConcurrency()`: Specifies the maximum number of Workers allowed concurrently in the current conversion session.
    - `setDefaultConfigurator()`: Change default configurator. Will be applied automatically for each conversion file if the file is not provided with the corresponding configurator.
- **ConvertConfigurator**: Class support for the Engine, the user will adjust it to specify to the Engine what the output file should like.
    - Just create a new configurator, supporting static method load config from file or from JSON: `fromFile()`, `fromJSON()`
- **PDFInfo**: Retrieve information about PDF files
    - `isPDF()`: Check if a buffer/file/stream/object is a PDF format or PDF presenter
    - `getPresenter()`: Creates a pdflib.PDFDocument instance representing the given PDF file. Used to interact with that PDF, or extends new features in the future (maybe?)
    - `getDocumentInfo()`: Retrieve information like title, author, creation dates, page counts, etc. from PDF file

## How to use it?

This module is geared towards simplicity for use and control from external. E.g:

```javascript
const engine = new ConvertEngine();
const configurator = ConvertConfigurator.fromJSON({
    width: '50%',
    height: '50%',
})

engine.setMaxConcurrency(2)
  .addFile('./in.pdf', './png/', {
    configurator,                   // Optional, halve output page size
    inputExtension: 'pdf',          // Must have
    outputExtension: 'png',         // Must have
    hooks: {
      resolveBadNaming: true,       // Resolve ugly output filenames. Eg: 105.png-1.png to 105.png
      clearCache: true,             // Delete temporary files in .cache folder
    }
  })
  .addFile('./in.pdf', './svg', {
    configurator: ConvertConfigurator.getDefault(),
    inputExtension: 'pdf',
    outputExtension: 'svg',
    hooks: {
      clearCache: true,
    }
  })

await engine.convert()
```

## How does it work?

Engine manages multiple Workers, each Worker is responsible for converting a file. Each file will be split into pages. Based on the maximum number of threads allowed by the Engine, Workers will allocate the number of LinkableCommands running in parallel for each respective ThreadPool.
For example: With only one Worker is running, Engine will deploy maximum threads (20). But when the number of Workers increases (e.g: 4), the number of parallel threads will be adjusted down (20/4=5 per Pool).
=> That's way make the system run stably while still ensuring overall conversion speed

## TODOs:
- [ ] Fix: CPU overload when focus accessing on one PDF file at a same time.
- [ ] Refactor: Remove smell code, redundant comments
- [ ] Perf: Fix delay between two convert sessions
- [ ] Feat: Support for cropping, grayscale filter

## Future plans:
- Detach as a separated repo once the current project done
- Detach helpers, utils and some other code into NPM packages for future reuse (if needed)